### PR TITLE
Activity tracker implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ association_count.rb
 .DS_Store
 .codesnip
 .backup
+dump.rdb

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,9 @@ gem 'sinatra', '>= 1.3.0', require: false
 gem 'active_model_serializers'
 # gem 'backport_new_renderer'
 
+# track users' activity
+gem 'public_activity'
+
 group :development, :test do
   gem "sqlite3"
   gem "pry-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,6 +172,11 @@ GEM
       pry (>= 0.9.10, < 0.11.0)
     pry-rails (0.3.4)
       pry (>= 0.9.10)
+    public_activity (1.4.2)
+      actionpack (>= 3.0.0)
+      activerecord (>= 3.0)
+      i18n (>= 0.5.0)
+      railties (>= 3.0.0)
     puma (3.1.0)
     rack (1.6.4)
     rack-cors (0.4.0)
@@ -317,6 +322,7 @@ DEPENDENCIES
   pg
   pry-nav
   pry-rails
+  public_activity
   puma
   rack-cors
   rack-timeout

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,7 @@
 class UsersController < ApplicationController
   include ProviderHelper
   before_action :set_user, only: [:update, :destroy, :questions, :tags]
+  before_action :set_user_with_activities, only: [:activities]
   before_action :set_user_with_associations_and_statistics, only: [:show]
   skip_before_action :authenticate_user, only: [:login, :authenticate]
 
@@ -61,11 +62,21 @@ class UsersController < ApplicationController
     render partial: 'tags/tag', locals: { tags: @user.tags }
   end
 
+  def activities
+    activities = @user.activities.paginate(page: params[:page]).with_basic_association
+    @activities = NestedResourcePaginationPresenter.new(activities, {id: @user.id})
+  end
+
   private
     def append_to_redirect_url(url, additional_params={})
       url += url.include?('?') ? '&' : '?'
       url += additional_params.to_query
       url
+    end
+
+    def set_user_with_activities
+      @user = User.find_by(id: params[:id])
+      resource_not_found && return unless @user
     end
 
     def set_user

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -6,11 +6,9 @@ class Activity < PublicActivity::Activity
       includes(:trackable).order(created_at: :desc)
     end
   end
-
   belongs_to :user, foreign_key: :owner_id
   validates :trackable, presence: true
   validates :key, presence: true
-
 
   def on?(resource_name)
     trackable_type == resource_name.to_s.capitalize

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,0 +1,59 @@
+class Activity < PublicActivity::Activity
+  include ZhishiDateHelper
+  class << self
+    delegate :route_key, to: :new
+    def with_basic_association
+      includes(:trackable).order(created_at: :desc)
+    end
+  end
+
+  belongs_to :user, foreign_key: :owner_id
+  validates :trackable, presence: true
+  validates :key, presence: true
+
+
+  def on?(resource_name)
+    trackable_type == resource_name.to_s.capitalize
+  end
+
+  def display_message
+    case activity_type
+    when 'create', 'index'
+      trackable.create_action_verb
+    when 'update'
+      trackable.update_action_verb
+    end
+  end
+
+  def activity_type
+    key.split('.').last
+  end
+
+  def related_information
+    parameters[:related_information]
+  end
+
+  def trackable_information
+    trackable.tracking_information
+  end
+
+  def url_for_trackable
+    trackable.zhishi_url_options.merge({
+      controller: trackable.route_key,
+      action: :show,
+      only_path: false
+    })
+  end
+
+  def url_for_question
+    if on?(:question)
+      { id: trackable_id }
+    else
+      { id: related_information[:id] }
+    end
+  end
+
+  def route_key
+    "activities_user"
+  end
+end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -4,6 +4,9 @@ class Answer < ActiveRecord::Base
   include VotesCounter
   include ModelJSONHashHelper
   include NewNotification
+  include UserActivityTracker
+  include ZhishiDateHelper
+  include RouteKey
 
   has_many :comments, as: :comment_on, dependent: :destroy
   has_many :votes, as: :voteable, dependent: :destroy
@@ -33,5 +36,24 @@ class Answer < ActiveRecord::Base
 
   def sort_value
     accepted ? Float::INFINITY : votes_count
+  end
+
+  def create_action_verb
+    "Answered a Question"
+  end
+
+  def update_action_verb
+    "Updated an Answer on a Question"
+  end
+
+  def should_create_activity?
+    true unless changed.include?('accepted')
+  end
+
+  def zhishi_url_options
+    {
+      question_id: question_id,
+      id: id
+    }
   end
 end

--- a/app/models/concerns/route_key.rb
+++ b/app/models/concerns/route_key.rb
@@ -1,0 +1,9 @@
+module RouteKey
+  extend ActiveSupport::Concern
+  included do
+    class << self
+      delegate :route_key, to: :model_name
+    end
+    delegate :route_key, to: :model_name
+  end
+end

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -34,7 +34,7 @@ module Searchable
   end
 
     def index_document_with_elastic_job
-      unless (content_that_should_not_be_indexed & self.changed) == self.changed
+      unless condition_for_reindexing?
         ElasticSearchSchedulerWorker.perform_async(:index, model_name.name, self.id)
       end
     end
@@ -46,4 +46,8 @@ module Searchable
     def content_that_should_not_be_indexed
       []
     end
+
+    def condition_for_reindexing?
+     (content_that_should_not_be_indexed & self.changed) == self.changed
+   end
 end

--- a/app/models/concerns/user_activity_tracker.rb
+++ b/app/models/concerns/user_activity_tracker.rb
@@ -1,0 +1,37 @@
+module UserActivityTracker
+  extend ActiveSupport::Concern
+
+  included do
+    include PublicActivity::Model
+
+    tracked owner: :user, recipient: :activity_on, except: [ :destroy ], params: {
+      related_information: :cache_question_information
+    }, on: { update: proc{|model, controller| model.should_create_activity? } }
+
+    has_many :activities, as: :trackable, dependent: :destroy
+  end
+
+  def should_create_activity?
+    true
+  end
+
+  def should_save_related_information?
+     respond_to? :question
+  end
+
+  def activity_on
+    question if should_save_related_information?
+  end
+
+  def cache_question_information
+    if should_save_related_information?
+      question.related_information
+    else
+      {}
+    end
+  end
+
+  def tracking_information
+    [:id, :content, :created_since]
+  end
+end

--- a/app/models/concerns/zhishi_date_helper.rb
+++ b/app/models/concerns/zhishi_date_helper.rb
@@ -1,0 +1,15 @@
+module ZhishiDateHelper
+  extend ActiveSupport::Concern
+
+  included do
+    include ActionView::Helpers::DateHelper
+  end
+
+  def created_since
+    distance_of_time_in_words(created_at, Time.zone.now) + " ago"
+  end
+
+  def updated_since
+    distance_of_time_in_words(updated_at, Time.zone.now) + " ago"
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,9 @@
 class User < ActiveRecord::Base
   include AndelaValidator
-  include ActionView::Helpers::DateHelper
   include NewNotification
-
+  include ZhishiDateHelper
+  include RouteKey
+  
   has_many :comments
   has_many :questions
   has_many :answers
@@ -11,6 +12,7 @@ class User < ActiveRecord::Base
   has_many :votes
   has_many :resource_tags, as: :taggable
   has_many :tags, through: :resource_tags
+  has_many :activities, foreign_key: :owner_id
   EMAIL_FORMAT= /(?<email>[.\w]+@andela).co[m]?\z/
 
   scope :with_statistics, Queries::StatisticsQuery
@@ -48,7 +50,7 @@ class User < ActiveRecord::Base
   end
 
   def member_since
-    distance_of_time_in_words(created_at, Time.zone.now) + " ago"
+    created_since
   end
 
   def self.with_associations

--- a/app/presenters/nested_resource_pagination_presenter.rb
+++ b/app/presenters/nested_resource_pagination_presenter.rb
@@ -1,0 +1,14 @@
+class NestedResourcePaginationPresenter < PaginationPresenter
+  attr_reader :default_params
+
+  def initialize(resource, default_params = {})
+    @default_params = default_params
+    super(resource)
+  end
+
+  def page_url(page_number)
+    with_page_number = default_params.merge(page: page_number)
+    send("#{resource.route_key}_path", with_page_number)
+  end
+
+end

--- a/app/presenters/pagination_presenter.rb
+++ b/app/presenters/pagination_presenter.rb
@@ -40,7 +40,7 @@ class PaginationPresenter
     end
 
     def page_url(page_number)
-      send("#{resource.model_name.route_key}_path", page: page_number)
+      send("#{resource.route_key}_path", page: page_number)
     end
 
     def method_missing(method_name, *args, &block)

--- a/app/views/users/activities.json.jbuilder
+++ b/app/views/users/activities.json.jbuilder
@@ -1,0 +1,15 @@
+json.activities(@activities) do |activity|
+  json.extract! activity, :key, :display_message
+  json.url url_for(activity.url_for_trackable)
+  json.activity_on do
+     json.type activity.trackable_type
+     json.activity_action activity.activity_type
+     # little hacking done here, bu the alternative would be to expand the following
+     #  line which would result in multiple lines with a following if as the
+    #  trackable_information are fetched from the resource being tracked
+     json.extract! activity.trackable, *activity.trackable_information
+     json.related_information activity.related_information
+     json.question_url question_url(activity.url_for_question)
+   end
+end
+json.partial! "application/shared/pagination", resource: @activities

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,7 @@ Rails.application.routes.draw do
       member do
         get :questions
         get :tags
+        get :activities
       end
 
       collection do

--- a/db/migrate/20160512093921_create_activities.rb
+++ b/db/migrate/20160512093921_create_activities.rb
@@ -1,0 +1,23 @@
+# Migration responsible for creating a table with activities
+class CreateActivities < ActiveRecord::Migration
+  # Create table
+  def self.up
+    create_table :activities do |t|
+      t.belongs_to :trackable, :polymorphic => true
+      t.belongs_to :owner, :polymorphic => true
+      t.string  :key
+      t.text    :parameters
+      t.belongs_to :recipient, :polymorphic => true
+
+      t.timestamps
+    end
+
+    add_index :activities, [:trackable_id, :trackable_type]
+    add_index :activities, [:owner_id, :owner_type]
+    add_index :activities, [:recipient_id, :recipient_type]
+  end
+  # Drop table
+  def self.down
+    drop_table :activities
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160401195419) do
+ActiveRecord::Schema.define(version: 20160512093921) do
+
+  create_table "activities", force: :cascade do |t|
+    t.integer  "trackable_id"
+    t.string   "trackable_type"
+    t.integer  "owner_id"
+    t.string   "owner_type"
+    t.string   "key"
+    t.text     "parameters"
+    t.integer  "recipient_id"
+    t.string   "recipient_type"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "activities", ["owner_id", "owner_type"], name: "index_activities_on_owner_id_and_owner_type"
+  add_index "activities", ["recipient_id", "recipient_type"], name: "index_activities_on_recipient_id_and_recipient_type"
+  add_index "activities", ["trackable_id", "trackable_type"], name: "index_activities_on_trackable_id_and_trackable_type"
 
   create_table "answers", force: :cascade do |t|
     t.integer  "user_id"

--- a/docs/user_endpoints.md
+++ b/docs/user_endpoints.md
@@ -9,6 +9,7 @@ GET /users	| Returns all users (possibly paginated)	| False
 GET /users/:id	| Returns information of a particular user	| False
 GET users/:id/questions| offset, limit ( both could be optional ), user_id, auth_token in header | Returns the questions with the user_id and all the information concerning it  or error message if any.
 GET users/:id/tags| offset, limit ( both could be optional ), user_id, auth_token in header | Returns the tags with the user_id or error message if any.
+GET users/:id/activities| offset, limit ( both could be optional ), user_id, auth_token in header | Returns the all the activities of a user with the user_id or error message if any.
 
 
 ### POST /users
@@ -177,4 +178,42 @@ Status 404
   {
 	  message: "Token seem valid but User record is not found"
   }
+```
+
+## GET /users/:id/activities
+Request
+```ruby
+  GET /users/1/activities
+```
+Response
+
+NOTE: When the activity is on a question, the related information field is an empty object
+
+```ruby
+Status: 200
+{
+  activities: [
+    {
+      "key": "answer.create",
+      "display_message": "Answered a Question",
+      "url": "/questions/1/answers/1",
+      "activity_on": {
+        "type": "Answer",
+        "activity_action": "create",
+        "id": 1,
+        "content": "The content of the answer",
+        "created_since": "2 minutes ago",
+        "related_information": {
+          "type": "Question",
+          "id": 1,
+          "title": "The title of the question",
+          "content": "The content of the question",
+          "user_id": 1,
+          "tags": []
+        },
+        "question_url": "/questions/1"
+      }
+    }
+  ]
+}
 ```

--- a/spec/factories/questions.rb
+++ b/spec/factories/questions.rb
@@ -40,7 +40,7 @@ FactoryGirl.define do
       end
 
       after(:create) do |question, evaluator|
-        create_list(:comment_on_question, evaluator.comments_count, comment_on: question)
+        create_list(:comment, evaluator.comments_count, comment_on: question)
       end
     end
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -23,7 +23,7 @@ FactoryGirl.define do
       end
 
       after(:create) do |user, evaluator|
-        create_list(:comment_on_question, evaluator.comments_count, user: user)
+        create_list(:comment, evaluator.comments_count, user: user)
       end
     end
 

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -1,0 +1,92 @@
+require 'rails_helper'
+
+RSpec.describe Activity, type: :model, track_activity: true do
+  [
+    {type: :question, class_name: 'Question', test_types: ["Answer", "Comment"]},
+    {type: :answer, class_name: 'Answer', test_types: ["Comment", "Question"]},
+    {type: :comment_on_answer, class_name: "Comment", test_types: ["Answer", "Question"]},
+    {type: :comment, class_name: "Comment", test_types: ["Answer", "Question"]}
+  ].each do |resource_info|
+
+    let(resource_info[:type]) { create(resource_info[:type]) }
+    let(:klass) { resource_info[:class_name] }
+    let(:test_types) { resource_info[:test_types] }
+    let(:resource) { send(resource_info[:type]) }
+
+    describe "#on?" do
+      subject { resource.activities.first }
+      context "when activity is on a question" do
+        it "should return true when the  checked parameter is the trackable_type" do
+          expect(subject.on?(klass)).to be true
+        end
+
+        it "should return false when checked against another trackable type" do
+          test_types.each do |test_against|
+            expect(subject.on?(test_against)).to be false
+          end
+        end
+      end
+    end
+
+    describe "#display_message" do
+      context "when no updates has been made to the resource" do
+        subject { resource.activities.first }
+        it "should return the create_action_message on the trackable" do
+          expect(subject.display_message).to eql(resource.create_action_verb)
+        end
+      end
+
+      context "when updates have been made to the resource" do
+        subject { resource.activities.last }
+        before do
+          resource.update(content: "This is the body of the resource")
+        end
+        it "should return the update_action_message on the trackable" do
+          expect(subject.display_message).to eql(resource.update_action_verb)
+        end
+      end
+    end
+
+
+    describe "#activity_type" do
+      context "when it is a new record" do
+        subject { resource.activities.first.activity_type }
+        it { should eql('create')}
+      end
+
+      context "when it is an updated record" do
+        subject { resource.activities.last.activity_type }
+        before do
+          resource.update(content: "This is the body of the resource")
+        end
+        it { should eql('update')}
+      end
+    end
+
+    describe "#related_information" do
+      subject { resource.activities.first.related_information }
+      it { should be_a Hash }
+    end
+
+    describe "#trackable_information" do
+      subject { resource.activities.first.trackable_information }
+      it { should eql(resource.tracking_information) }
+    end
+
+    describe "#url_for_trackable" do
+      subject { resource.activities.first.url_for_trackable }
+      it { should include(resource.zhishi_url_options) }
+      it { should include({ action: :show, controller: resource.route_key })}
+    end
+
+    describe "#url_for_question" do
+      subject { resource.activities.first.url_for_question }
+      if resource_info[:type] == :question
+        it { should eql(id: resource.id)}
+      else
+        it { should eql(id: resource.question.id)}
+      end
+    end
+    
+  end
+end

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -170,4 +170,5 @@ RSpec.describe Answer, type: :model do
   end
 
   it_behaves_like "a votable", :answer_with_votes
+  it_behaves_like :activity_tracker, :answer
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -89,4 +89,7 @@ RSpec.describe Comment, type: :model do
   end
 
   it_behaves_like "a votable", :comment_with_votes
+  it_behaves_like :activity_tracker, :comment
+  it_behaves_like :activity_tracker, :comment_on_answer
+
 end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -4,8 +4,6 @@ RSpec.describe Question, type: :model do
   let(:user) { build(:user) }
   let(:question){create(:question, user: user)}
 
-  it_behaves_like "a votable", :question_with_votes
-
   describe "#time_updated" do
     it "returns nil if time is not updated" do
       expect(question.time_updated).to be nil
@@ -101,4 +99,8 @@ RSpec.describe Question, type: :model do
       expect(question.as_indexed_json).to eql obj_format
     end
   end
+
+
+  it_behaves_like "a votable", :question_with_votes
+  it_behaves_like :activity_tracker, :question
 end

--- a/spec/models/shared/activity_tracker.rb
+++ b/spec/models/shared/activity_tracker.rb
@@ -1,0 +1,24 @@
+RSpec.shared_examples :activity_tracker do |described_class_factory|
+
+  let!(:subject) { create(described_class_factory) }
+
+  it { should have_many(:activities) }
+
+  context "when a record is Updated", track_activity: true do
+    it "should increment activities count by 1" do
+      expect {
+        subject.update(content: "Why should I care")
+      }.to change(Activity, :count).by(1)
+    end
+  end
+
+  context "when a record is Deleted", track_activity: true do
+    it "should delete all associated activities" do
+      activities_count = subject.activities.count
+      expect {
+        subject.destroy
+      }.to change(Activity, :count).by(-(activities_count))
+    end
+  end
+
+end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe Tag, type: :model do
       it "updates the parent tag of with the given tag" do
         tag = create(:tag)
         tag1 = create(:tag)
-        expect(tag.representative).to be_nil
+        expect(tag.representative_id).to be_nil
         tag.update_parent(tag1)
         expect(tag.representative).to eql tag1
         tag.update_parent(new_rep)

--- a/spec/serializers/notifications/comment_serializer_spec.rb
+++ b/spec/serializers/notifications/comment_serializer_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Notifications::CommentSerializer do
   end
 
   context "comment on question" do
-    let(:comment) { create(:comment_on_question) }
+    let(:comment) { create(:comment) }
 
     it_behaves_like :shared_comment_serializer
 

--- a/spec/serializers/notifications/new_comment_serializer_spec.rb
+++ b/spec/serializers/notifications/new_comment_serializer_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Notifications::NewCommentSerializer do
   end
 
   context "comment on question" do
-    let(:comment) { create(:comment_on_question) }
+    let(:comment) { create(:comment) }
     it_behaves_like :shared_comment_serializer
 
   end

--- a/spec/support/activity_tracking_helper.rb
+++ b/spec/support/activity_tracking_helper.rb
@@ -1,0 +1,10 @@
+require 'public_activity/testing'
+
+PublicActivity.enabled = false
+RSpec.configure do |config|
+  config.around(:each, track_activity: true) do |example|
+    PublicActivity.with_tracking do
+      example.run
+    end
+  end
+end

--- a/spec/support/schemas/user/activities.json
+++ b/spec/support/schemas/user/activities.json
@@ -1,0 +1,29 @@
+{
+  "type": "object",
+  "properties":{
+    "activities":{
+      "type": "array",
+      "properties":{
+        "key": { "type": "string" },
+        "display_message": { "type": ["string", "nil"] },
+        "url": { "type": "string" },
+        "activity_on": {
+          "type": "object",
+          "properties": {
+            "type": { "type": "string" },
+            "activity_action": { "type": "string" },
+            "id": { "type": "int" },
+            "content": { "type": "string" },
+            "created_since": { "type": "string" },
+            "related_information": {
+              "type": ["object", "nil"]
+            }
+          }
+        }
+      }
+    },
+    "meta": {
+      "$ref": "../pagination/pagination.json#/definitions/meta"
+    }
+  }
+}


### PR DESCRIPTION
Implementation of the User activity feed for Zhishi.
This PR allows the clients to create a feed for showing user's activities(asking a question, answering a question, commenting or updating a resource) on Zhishi.