### PR TITLE
re-Sidekiq Workers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ group :test do
   gem 'elasticsearch-extensions'
   gem "json-schema"
   gem "mock_redis"
+  gem 'rspec-sidekiq'
 end
 
 group :production, :staging do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -248,6 +248,9 @@ GEM
       rspec-expectations (~> 3.4.0)
       rspec-mocks (~> 3.4.0)
       rspec-support (~> 3.4.0)
+    rspec-sidekiq (2.2.0)
+      rspec (~> 3.0, >= 3.0.0)
+      sidekiq (>= 2.4.0)
     rspec-support (3.4.1)
     ruby-prof (0.15.9)
     ruby_dep (1.3.1)
@@ -331,6 +334,7 @@ DEPENDENCIES
   rails_12factor
   redis-namespace
   rspec-rails
+  rspec-sidekiq
   shoulda-matchers
   sidekiq
   sidekiq-failures

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: bundle exec puma -C config/puma.rb
+web: bundle exec puma -C config/puma.rb -p $PORT
 worker: bundle exec sidekiq -C config/sidekiq.yml

--- a/app/models/concerns/new_notification.rb
+++ b/app/models/concerns/new_notification.rb
@@ -5,7 +5,7 @@ module NewNotification
   end
 
   def notify
-    NotificationSystemWorker.perform_async(model_name.to_s, id)
+    NotificationSystemWorker.perform_in(5.seconds, model_name.to_s, id)
   end
 
   def object_for_notification

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -35,12 +35,12 @@ module Searchable
 
     def index_document_with_elastic_job
       unless condition_for_reindexing?
-        ElasticSearchSchedulerWorker.perform_async(:index, model_name.name, self.id)
+        ElasticSearchSchedulerWorker.perform_in(5.seconds, :index, model_name.name, self.id)
       end
     end
 
     def delete_document_from_elastic_with_job
-      ElasticSearchSchedulerWorker.perform_async(:delete, model_name.name, self.id)
+      ElasticSearchSchedulerWorker.perform_in(5.seconds, :delete, model_name.name, self.id)
     end
 
     def content_that_should_not_be_indexed

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,9 +1,12 @@
+require 'redis/namespace'
+
 Redis.current = ConnectionPool.new(size: (Sidekiq.server? ? 5 : 1), timeout: 5) do
-  Redis.new(url: ENV['REDISTOGO_URL'])
+  Redis::Namespace.new(:zhishi, redis: Redis.new(url: ENV['REDISTOGO_URL']))
 end
 
 Sidekiq.configure_server do |config|
   config.redis = Redis.current
+  config.average_scheduled_poll_interval = 10
 end
 
 Sidekiq.configure_client do |config|

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -12,7 +12,7 @@
 
 common: &default_settings
   # Required license key associated with your New Relic account.
-  license_key: 72d898b4665ce655ede38eedf0aea02192d5f3e3
+  license_key: <%= ENV["NEW_RELIC_LICENSE_KEY"] %>
 
   # Your application name. Renaming here affects where data displays in New
   # Relic.  For more details, see https://docs.newrelic.com/docs/apm/new-relic-apm/maintenance/renaming-applications

--- a/db/migrate/20160525060037_update_user_activity_record_for_current_resources.rb
+++ b/db/migrate/20160525060037_update_user_activity_record_for_current_resources.rb
@@ -1,0 +1,16 @@
+class UpdateUserActivityRecordForCurrentResources < ActiveRecord::Migration
+  def up
+    [Question, Comment, Answer].each do |model_klass|
+      model_klass.includes(:activities).find_each do |resource|
+        activities = resource.activities.pluck(:key)
+        if activities.grep(/create|index/).empty?
+          resource.create_activity :create
+        end
+      end
+    end
+  end
+
+  def down
+    PublicActivity::Activity.delete_all
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160512093921) do
+ActiveRecord::Schema.define(version: 20160525060037) do
 
   create_table "activities", force: :cascade do |t|
     t.integer  "trackable_id"

--- a/docs/tags_endpoints.md
+++ b/docs/tags_endpoints.md
@@ -2,11 +2,12 @@
 
 Endpoints |	Usage |	Public Access
 --------- | ----- | -------------
-GET /tags/?q=query |	Returns the tags that match the given the argument (autocomplete feature) |	True
-GET /tags/popular | Returns the popular tags | True
-GET /tags/recent | Returns the recent tags | True
-GET /tags/trending | Returns the trending tags | True
-POST /tags/update_subscription | Returns the users tags | True
+GET /tags/?q=query |	Returns the tags that match the given the argument (autocomplete feature) |	False
+GET /tags/popular | Returns the popular tags | False
+GET /tags/recent | Returns the recent tags | False
+GET /tags/trending | Returns the trending tags | False
+GET /tags/subscribable | Returns all tags that can be subscribed to. | False
+POST /tags/update_subscription | Returns the users tags | False
 
 ### GET /tags/?q=query
 
@@ -71,6 +72,21 @@ Status: 200
 ```
 
 ### GET /tags/trending
+Response
+```ruby
+Status: 200
+{
+  tags: [
+    {
+      name: 'mac',
+      id: 1,
+      representative_id: nil
+    }
+  ]
+}
+```
+
+### GET /tags/subscribable
 Response
 ```ruby
 Status: 200

--- a/spec/workers/elastic_search_scheduler_worker_spec.rb
+++ b/spec/workers/elastic_search_scheduler_worker_spec.rb
@@ -1,29 +1,21 @@
 require 'rails_helper'
 RSpec.describe ElasticSearchSchedulerWorker, type: :worker do
-  before do
-    allow(described_class).to receive(:perform_async)
-  end
-
   [:question, :tag].each do |factory|
     describe '#perform' do
       context "when document is to be indexed" do
 
         it 'passes the document record to be indexed' do
           record = create(factory)
-
-          expect(described_class).to have_received(:perform_async).with(:index, record.model_name.name, record.id)
+          expect(described_class).to have_enqueued_job('index', record.model_name.name, record.id)
         end
       end
 
       context "when document is to be deleted" do
-        before do
-          @record = create(factory)
-        end
+        let(:record) { create(factory) }
 
         it 'passes the document record to be indexed' do
-          @record.destroy
-
-          expect(described_class).to have_received(:perform_async).with(:delete, @record.model_name.name, @record.id)
+          record.destroy
+          expect(described_class).to have_enqueued_job('delete', record.model_name.name, record.id)
         end
       end
     end

--- a/spec/workers/notification_system_worker_spec.rb
+++ b/spec/workers/notification_system_worker_spec.rb
@@ -1,11 +1,6 @@
 require 'rails_helper'
 RSpec.describe NotificationSystemWorker, type: :worker do
-  before do
-    allow(described_class).to receive(:perform_async)
-  end
-
   [:question, :answer, :comment, :user].each do |resource|
-
     describe '#perform' do
       context "when new #{resource} is created" do
 
@@ -13,7 +8,7 @@ RSpec.describe NotificationSystemWorker, type: :worker do
           record = create(resource)
           klass = record.model_name.to_s
 
-          expect(described_class).to have_received(:perform_async).with(klass, record.id)
+          expect(described_class).to have_enqueued_job(klass, record.id)
         end
       end
     end

--- a/spec/workers/tag_representative_assignment_worker_spec.rb
+++ b/spec/workers/tag_representative_assignment_worker_spec.rb
@@ -1,15 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe TagRepresentativeAssignmentWorker, type: :worker do
-  before do
-    allow(described_class).to receive(:perform_async)
-  end
-
   describe "#perform" do
     it "receives the tags arguments passed to it" do
       tag = create(:tag)
-
-      expect(described_class).to have_received(:perform_async).with(tag.id, tag.name)
+      expect(described_class).to have_enqueued_job(tag.id, tag.name)
     end
 
     context "update tag representative" do

--- a/spec/workers/tag_subscription_reassignment_worker_spec.rb
+++ b/spec/workers/tag_subscription_reassignment_worker_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe TagSubscriptionReassignmentWorker, type: :worker do
   before do
-    allow(described_class).to receive(:perform_async)
     create_list(:tag, 3, name: 'tag')
   end
 
@@ -12,7 +11,7 @@ RSpec.describe TagSubscriptionReassignmentWorker, type: :worker do
     it "receives the tag params for reassignment" do
       tag.update(representative: Tag.first)
 
-      expect(described_class).to have_received(:perform_async).with(tag.id)
+      expect(described_class).to have_enqueued_job(tag.id)
     end
 
     it "executes #update_tag_subscriptions" do


### PR DESCRIPTION
SideKiq gets to run before some resources are fully persisted to the database, which often results in a record not found error.
Changed the perform_async method to instead perform in 5 seconds(which is a reasonable time for a record to have been persisted).
Also added the rspec-sidekiq gem so as to enable testing with the sidekiq helpers/matchers.