### PR TITLE
add rake task for remaping tags

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -11,7 +11,7 @@ class Tag < ActiveRecord::Base
   has_many :similar_tags, class_name: 'Tag', foreign_key: 'representative_id'
   belongs_to :representative, class_name: 'Tag'
 
-  before_save :downcase!, :strip!
+  before_save :downcase!, :strip!, :ensure_naming_convention
   after_create :push_representative_assignment_to_sidekiq
   after_update :push_subscription_update_to_sidekiq, if: :representative_id_changed?
 
@@ -97,6 +97,10 @@ class Tag < ActiveRecord::Base
 
   def representative
     super || self
+  end
+
+  def ensure_naming_convention
+    self.name = self.name.split.join("-")
   end
 
   private

--- a/lib/tasks/remap_tags.rake
+++ b/lib/tasks/remap_tags.rake
@@ -1,0 +1,63 @@
+namespace :remap_tags do
+
+  desc "this task remaps and deletes tags. This is a one time task!"
+  task execute: :environment do
+    map_tags
+    rename_and_delete_tags
+    puts "Completed!!!"
+  end
+
+  def map_tags
+    tags = {
+            "food" => ["meals"],
+            "fellows-lagos" => ["fellows lagos", "lagos"],
+            "php" => ["pdo", "laravel", "dbal"],
+            "training" => ["cousera", "simulations"],
+            "sports" =>["football"],
+            "healthcare" => ["kbl", "bupa", "health"],
+            "javascript" => ["dom", "superagent"],
+            "react" => ["react router"],
+            "ruby" => ["rspec", "serializers"],
+            "testing" => ["faker", "mock", "stub", "unit-testing"],
+            "operations" => ["leave", "leave-request", "annual-leave"],
+            "mac" => ["osx"],
+            "nairobi-fellows" => ["brown-bag", "kenya"],
+            "databases" => ["sql", "database-relation"],
+            "api" => ["rest"],
+            "css" => ["flexbox"]
+            }
+
+    tags.each do |key, value|
+      parent_tag = Tag.where(name: key)
+      Tag.where(name: value).update_all(representative_id: parent_tag)
+    end
+    puts "Sucessfuly Mapped Tags!"
+  end
+
+  def rename_and_delete_tags
+    old_tags = {
+                "module" => "ruby",
+                "survey" => "fellows",
+                "staff" => "operations",
+                "queries" => "databases",
+                "deployment" => "laravel"
+                }
+
+    old_tags.each do |key, value|
+        new_tag = Tag.where(name: value)
+        ResourceTag.joins(:tag).where(tags: {name: key}).update_all(tag_id: new_tag)
+    end
+
+    tags_to_delete = ["computer", "operation", "forms", "networking", "pdo-connection",
+     "paid-courses", "programming", "associations", "facility", "ci", "mixin",
+     "discussion", "promotions", "beautiful soup"] + old_tags.keys
+
+    Tag.where(name: "orders").update_all(name: "NY-Office")
+    Tag.where(name: "history").update_all(name: "andela-history")
+    Tag.where(name: "databases").update_all(name: "database")
+
+    Tag.where(name: tags_to_delete).destroy_all
+
+    puts "Sucessfuly Renamed And Deleted Unwanted Tags!!"
+  end
+end

--- a/lib/tasks/remap_tags.rake
+++ b/lib/tasks/remap_tags.rake
@@ -4,6 +4,7 @@ namespace :remap_tags do
   task execute: :environment do
     map_tags
     rename_and_delete_tags
+    implement_new_tag_naming_convention
     puts "Completed!!!"
   end
 
@@ -22,7 +23,7 @@ namespace :remap_tags do
             "operations" => ["leave", "leave-request", "annual-leave"],
             "mac" => ["osx"],
             "nairobi-fellows" => ["brown-bag", "kenya"],
-            "databases" => ["sql", "database-relationships"],
+            "databases" => ["sql", "database relationships"],
             "api" => ["rest"],
             "css" => ["flexbox"]
             }
@@ -52,12 +53,20 @@ namespace :remap_tags do
      "paid-courses", "programming", "associations", "facility", "ci", "mixin",
      "discussion", "promotions", "beautiful soup"] + old_tags.keys
 
-    Tag.where(name: "orders").update_all(name: "NY-Office")
+    Tag.where(name: "orders").update_all(name: "ny-office")
     Tag.where(name: "history").update_all(name: "andela-history")
     Tag.where(name: "databases").update_all(name: "database")
 
     Tag.where(name: tags_to_delete).destroy_all
 
     puts "Sucessfuly Renamed And Deleted Unwanted Tags!!"
+  end
+
+  def implement_new_tag_naming_convention
+    Tag.find_each do |tag|
+      name = tag.name.split(' ').join('-')
+      tag.update(name: name)
+    end
+    puts "Naming convention successfully implemented"
   end
 end

--- a/lib/tasks/remap_tags.rake
+++ b/lib/tasks/remap_tags.rake
@@ -22,7 +22,7 @@ namespace :remap_tags do
             "operations" => ["leave", "leave-request", "annual-leave"],
             "mac" => ["osx"],
             "nairobi-fellows" => ["brown-bag", "kenya"],
-            "databases" => ["sql", "database-relation"],
+            "databases" => ["sql", "database-relationships"],
             "api" => ["rest"],
             "css" => ["flexbox"]
             }
@@ -48,7 +48,7 @@ namespace :remap_tags do
         ResourceTag.joins(:tag).where(tags: {name: key}).update_all(tag_id: new_tag)
     end
 
-    tags_to_delete = ["computer", "operation", "forms", "networking", "pdo-connection",
+    tags_to_delete = ["computer science", "operation", "forms", "networking", "pdo-connection",
      "paid-courses", "programming", "associations", "facility", "ci", "mixin",
      "discussion", "promotions", "beautiful soup"] + old_tags.keys
 


### PR DESCRIPTION
This PR adds a rake task for remapping tags. The task will be carried out by running `rake remap_tags:execute`